### PR TITLE
Correct DEBUG printf arguments order

### DIFF
--- a/rpncomm/RPN_COMM_mgi.c
+++ b/rpncomm/RPN_COMM_mgi.c
@@ -875,7 +875,7 @@ static int MPI_mgi_Publish_name(const char *service_name, MPI_Info info, const c
     }
 if(DEBUG) printf("DEBUG %d: publishing in %s\n",debug_rank,filenew);
   }else{                            //  default directory for MPI channel files
-if(DEBUG) printf("DEBUG %d: publishing in %s, MGI_MPI_HOME='%s'\n",".gossip/MPI",debug_rank,mpi_mgi_home);
+if(DEBUG) printf("DEBUG %d: publishing in %s, MGI_MPI_HOME='%s'\n",debug_rank,".gossip/MPI",mpi_mgi_home);
     snprintf(filename,4096,"%s/%s",getenv("HOME"),".gossip");
     mkdir(filename,0755);
     snprintf(filename,4096,"%s/%s",getenv("HOME"),".gossip/MPI");


### PR DESCRIPTION
@mfvalin, je pense que les arguments d'un énoncé printf dans RPN_COMM_mgi doivent être inversés, tel que discuté en personne la semaine dernière. Autrement, j'ai une erreur de compilation :
`RPN_COMM_mgi.c:878:1: warning: format ‘%s’ expects argument of type ‘char 
*’, but argument 3 has type ‘int’ [-Wformat=]`
